### PR TITLE
GB: Default to greyscale palette instead of Wario Blast if no GBC pal…

### DIFF
--- a/src/lcd.s
+++ b/src/lcd.s
@@ -334,9 +334,9 @@ GFX_reset:	@called with CPU reset
 	@get GBC palette
 	ldr_ r0,memmap_tbl
 	blx_long GetGbcPaletteNumber
-	@if zero, pick Wario Blast palette
+	@if zero, pick greyscale
 	cmp r0,#0
-	moveq r0,#74
+	moveq r0,#01
 	ldr r1,=palettebank
 	strb r0,[r1]
 	bl paletteinit


### PR DESCRIPTION
…ette avaliable

on real GBC hardware, there is a set of colour palettes that can be applied to compatiable games. if there is not a palette for a specific game, it will select the 'wario blast' palette instead. however, this looks very ugly in some games. this commit makes it so that if there is no GBC palette avaliable, it will instead select a greyscale palette by default, which would look much less ugly.

(games which do have specific palettes chosen for them will be unaffected.)