### PR TITLE
[Faceball 2000] Fix serial transfer -- add IRQ delay

### DIFF
--- a/src/io.s
+++ b/src/io.s
@@ -1208,11 +1208,6 @@ _FF01W:@		SB - Serial Transfer Data
 _FF02W:@		SC - Serial Transfer Ctrl
 @----------------------------------------------------------------------------
 	strb_ r0,stctrl
-	and r0,r0,#0x81
-	cmp r0,#0x81		@Are going to transfer on internal clock?
-	ldreqb_ r0,gb_if		@IRQ flags
-	orreq r0,r0,#8		@8=Serial
-	streqb_ r0,gb_if
 	mov pc,lr
 @----------------------------------------------------------------------------
 _FF56W:@		RP - Infrared Port

--- a/src/timeout.s
+++ b/src/timeout.s
@@ -459,11 +459,17 @@ checkTimerIRQ:
 noTimerIRQ:
 	str_ r0,timercounter
 noTimer:
-	ldrb_ r1,gb_if
-	tst r1,#0x08			@Serial
-	ldrneb_ r0,stctrl
-	andne r0,r0,#0x7F		@Clear Serial Transfer flag.
-	strneb_ r0,stctrl
+	ldrb_ r1,stctrl
+	and r1,r1,#0x81
+	cmp r1,#0x81		@Are going to transfer on internal clock?
+
+	ldreqb_ r1,gb_if		@IRQ flags
+	orreq r1,r1,#8		@8=Serial
+	streqb_ r1,gb_if
+
+	ldreqb_ r0,stctrl
+	andeq r0,r0,#0x7F		@Clear Serial Transfer flag.
+	streqb_ r0,stctrl
 checkMasterIRQDelayed:
 	tst cycles,#CYC_IE
 	beq _GO


### PR DESCRIPTION
From @radimerry's fork. Both GB and DX versions playable.