### PR TITLE
[SML DX] Mapper fix - disable SRAM on default

### DIFF
--- a/src/mappers.s
+++ b/src/mappers.s
@@ -61,6 +61,11 @@ mbc0init:
 mbc1init:
 @----------------------------------------------------------------------------
 	.word RamEnable,MBC1map0,MBC1map1,MBC1mode
+
+	ldr r0,=empty_W					@ Disable RAM = $00
+	str_ r0,writemem_tbl+40
+	str_ r0,writemem_tbl+44
+
 	mov pc,lr
 	
 	.popsection
@@ -105,6 +110,11 @@ MBC1mode:
 mbc2init:
 @----------------------------------------------------------------------------
 	.word MBC2RamEnable,MBC2map,void,void
+
+	ldr r0,=empty_W					@ Disable RAM = $00
+	str_ r0,writemem_tbl+40
+	str_ r0,writemem_tbl+44
+
 	mov pc,lr
 	.popsection
 @----------------------------------------------------------------------------
@@ -126,6 +136,11 @@ MBC2RamEnable:
 mbc3init:
 @----------------------------------------------------------------------------
 	.word RamEnable,map4567_,mbc3bank,mbc3latchtime
+
+	ldr r0,=empty_W					@ Disable RAM = $00
+	str_ r0,writemem_tbl+40
+	str_ r0,writemem_tbl+44
+
 	mov pc,lr
 @----------------------------------------------------------------------------
 mbc3latchtime:
@@ -196,6 +211,11 @@ calctime:
 mbc5init:
 @----------------------------------------------------------------------------
 	.word RamEnable,MBC5map0,MBC5RAMB,void
+
+	ldr r0,=empty_W					@ Disable RAM = $00
+	str_ r0,writemem_tbl+40
+	str_ r0,writemem_tbl+44
+
 	mov pc,lr
 	.popsection
 @----------------------------------------------------------------------------
@@ -282,6 +302,11 @@ huc1init:
 @----------------------------------------------------------------------------
 	.word RamEnable,HUC1map0,MBC1map1,MBC1mode
 @	DCD RamEnable,HUC1map0,MBC5RAMB,void
+
+	ldr r0,=empty_W					@ Disable RAM = $00
+	str_ r0,writemem_tbl+40
+	str_ r0,writemem_tbl+44
+
 	mov pc,lr
 	.popsection
 @----------------------------------------------------------------------------
@@ -299,6 +324,11 @@ HUC1map0:
 huc3init:
 @----------------------------------------------------------------------------
 	.word RamEnable,map4567_,MBC5RAMB,void
+
+	ldr r0,=empty_W					@ Disable RAM = $00
+	str_ r0,writemem_tbl+40
+	str_ r0,writemem_tbl+44
+
 	mov pc,lr
 
 @----------------------------------------------------------------------------
@@ -307,6 +337,11 @@ mbc4init:
 mbc6init:
 @----------------------------------------------------------------------------
 	.word RamEnable,map4567_,void,void
+
+	ldr r0,=empty_W					@ Disable RAM = $00
+	str_ r0,writemem_tbl+40
+	str_ r0,writemem_tbl+44
+
 	mov pc,lr
 	.popsection
 


### PR DESCRIPTION
From @radimerry's fork. Saves work here. Also confirmed works here.
https://github.com/EvilJagaGenius/jagoombacolor/issues/16