### PR TITLE
Allow saved display setting to be used when no palette is detected

### DIFF
--- a/src/lcd.s
+++ b/src/lcd.s
@@ -334,10 +334,14 @@ GFX_reset:	@called with CPU reset
 	@get GBC palette
 	ldr_ r0,memmap_tbl
 	blx_long GetGbcPaletteNumber
-	@if zero, pick greyscale
-	cmp r0,#0
-	moveq r0,#01
+	@if no GBC palette saved, pick greyscale
 	ldr r1,=palettebank
+	ldr r2,[r1]
+	cmp r1,#0
+	moveq r2,#01
+	@if no GBC palette detected, use saved or greyscale
+	cmp r0,#0
+	moveq r0,r2
 	strb r0,[r1]
 	bl paletteinit
 1:


### PR DESCRIPTION
Tested this on my Everdrive mini with a few GB games.

There two ways this could be done:
1) Detected palette gets priority over saved palette
2) Saved palette gets priority over detected palette

I went with the first method. If the second method is preferred I can adjust the code.

In the case where neither a detected palette or a saved palette are available it uses greyscale. 